### PR TITLE
Fix Django template logic parsing for widgets

### DIFF
--- a/frontend/src/components/LayoutRenderer.js
+++ b/frontend/src/components/LayoutRenderer.js
@@ -3071,7 +3071,7 @@ class LayoutRenderer {
         element = this.templateRenderer.processTemplateStructureWithLogic(templateJson.structure, config, templateTags);
       } else {
         // Use standard processing for simple templates
-        element = this.processTemplateStructure(templateJson.structure, config);
+        element = this.templateRenderer.processTemplateStructure(templateJson.structure, config);
       }
 
       // Handle inline CSS if present
@@ -4210,7 +4210,7 @@ class LayoutRenderer {
         return;
       }
 
-      const validTypes = ['element', 'template_text', 'text', 'style', 'fragment', 'conditional_block'];
+      const validTypes = ['element', 'template_text', 'text', 'style', 'fragment', 'conditional_block', 'loop_block'];
       if (!validTypes.includes(structure.type)) {
         warnings.push(`Unknown structure type: ${structure.type}`);
       }

--- a/frontend/src/components/LayoutRenderer.js
+++ b/frontend/src/components/LayoutRenderer.js
@@ -4215,6 +4215,43 @@ class LayoutRenderer {
         warnings.push(`Unknown structure type: ${structure.type}`);
       }
 
+      // Validate type-specific properties
+      switch (structure.type) {
+        case 'conditional_block':
+          if (!structure.condition || typeof structure.condition !== 'string') {
+            errors.push('conditional_block missing valid condition property');
+          }
+          if (!structure.content) {
+            errors.push('conditional_block missing content property');
+          } else {
+            this.validateTemplateStructure(structure.content, errors, warnings);
+          }
+          break;
+
+        case 'loop_block':
+          if (!structure.loop || typeof structure.loop !== 'string') {
+            errors.push('loop_block missing valid loop property');
+          }
+          if (!structure.content) {
+            errors.push('loop_block missing content property');
+          } else {
+            this.validateTemplateStructure(structure.content, errors, warnings);
+          }
+          break;
+
+        case 'fragment':
+          if (!structure.children || !Array.isArray(structure.children)) {
+            warnings.push('fragment should have children array');
+          }
+          break;
+
+        case 'element':
+          if (!structure.tag || typeof structure.tag !== 'string') {
+            errors.push('element missing valid tag property');
+          }
+          break;
+      }
+
       // Validate children if present
       if (structure.children && Array.isArray(structure.children)) {
         structure.children.forEach((child, index) => {

--- a/frontend/src/utils/DjangoTemplateRenderer.js
+++ b/frontend/src/utils/DjangoTemplateRenderer.js
@@ -286,16 +286,46 @@ class DjangoTemplateRenderer {
                     return this.processFragment(structure, config);
 
                 case 'conditional_block':
-                    // Handle conditional blocks in standard processing too
-                    const shouldRender = this.evaluateCondition(structure.condition, config);
-                    if (shouldRender && structure.content) {
-                        return this.processTemplateStructure(structure.content, config);
+                    // Handle conditional blocks with proper error handling
+                    try {
+                        if (!structure.condition || typeof structure.condition !== 'string') {
+                            console.warn('DjangoTemplateRenderer: Invalid condition in conditional_block');
+                            return document.createTextNode('<!-- Invalid condition -->');
+                        }
+
+                        const shouldRender = this.evaluateCondition(structure.condition, config);
+                        if (shouldRender && structure.content) {
+                            // Validate content structure before processing
+                            if (typeof structure.content !== 'object' || !structure.content.type) {
+                                console.warn('DjangoTemplateRenderer: Invalid content in conditional_block');
+                                return document.createTextNode('<!-- Invalid content structure -->');
+                            }
+                            return this.processTemplateStructure(structure.content, config);
+                        }
+                        return document.createTextNode('');
+                    } catch (error) {
+                        console.error('DjangoTemplateRenderer: Error processing conditional_block', error);
+                        return document.createTextNode('<!-- Conditional block error -->');
                     }
-                    return document.createTextNode('');
 
                 case 'loop_block':
-                    // Handle loop blocks in standard processing too
-                    return this.processLoopLogic(structure, config, []);
+                    // Handle loop blocks with proper error handling
+                    try {
+                        if (!structure.loop || typeof structure.loop !== 'string') {
+                            console.warn('DjangoTemplateRenderer: Invalid loop expression in loop_block');
+                            return document.createTextNode('<!-- Invalid loop expression -->');
+                        }
+
+                        if (!structure.content || typeof structure.content !== 'object') {
+                            console.warn('DjangoTemplateRenderer: Invalid content in loop_block');
+                            return document.createTextNode('<!-- Invalid loop content -->');
+                        }
+
+                        return this.processLoopLogic(structure, config, []);
+                    } catch (error) {
+                        console.error('DjangoTemplateRenderer: Error processing loop_block', error);
+                        return document.createTextNode('<!-- Loop block error -->');
+                    }
 
                 default:
                     if (this.debug) {

--- a/frontend/src/utils/DjangoTemplateRenderer.js
+++ b/frontend/src/utils/DjangoTemplateRenderer.js
@@ -285,6 +285,18 @@ class DjangoTemplateRenderer {
                 case 'fragment':
                     return this.processFragment(structure, config);
 
+                case 'conditional_block':
+                    // Handle conditional blocks in standard processing too
+                    const shouldRender = this.evaluateCondition(structure.condition, config);
+                    if (shouldRender && structure.content) {
+                        return this.processTemplateStructure(structure.content, config);
+                    }
+                    return document.createTextNode('');
+
+                case 'loop_block':
+                    // Handle loop blocks in standard processing too
+                    return this.processLoopLogic(structure, config, []);
+
                 default:
                     if (this.debug) {
                         console.warn(`DjangoTemplateRenderer: Unknown template structure type: ${structure.type}`);


### PR DESCRIPTION
## Problem Fixed

Text Block widgets and other widgets with Django template logic were displaying raw Django template code instead of rendered content:

```
{% if config.title %}
Title
{% endif %} {% if config.content %}
Content
{% endif %}
```

## Root Cause

BeautifulSoup parser was treating Django template tags (`{% if %}`, `{% endif %}`) as plain text nodes instead of template logic, causing them to be included literally in the template_json structure.

## Solution

### Backend Changes (`backend/webpages/utils/template_parser.py`):
- Added pre-processing method to convert Django template logic into parseable HTML elements
- `{% if config.title %}...{% endif %}` → `<template-conditional data-condition="config.title">...</template-conditional>`
- Added parsing support for `template-conditional` and `template-loop` elements
- Generates proper `conditional_block` and `loop_block` JSON structures

### Frontend Changes:
- **LayoutRenderer.js**: Fixed method call to use DjangoTemplateRenderer correctly
- **DjangoTemplateRenderer.js**: Added support for `conditional_block` and `loop_block` types
- Updated validation to include new template structure types

## Result

✅ Text Block widgets now properly render conditional content  
✅ Template variables like `{{ config.title }}` still work correctly  
✅ No more raw Django template syntax displayed to users  
✅ Maintains backward compatibility with existing widgets  

## Testing

- Verified backend generates correct `conditional_block` structures
- Tested Text Block widget renders conditionally based on config
- Template variables and filters continue to work as expected

Resolves the widget rendering issue where Django template logic appeared literally instead of being processed.